### PR TITLE
[cmake] Install config files into architecture-independent directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ set(INSTALL_INCLUDE_DIR include CACHE PATH "Installation directory for header fi
 if (WIN32 AND NOT CYGWIN)
   set (DEF_INSTALL_CMAKE_DIR cmake)
 else ()
-  set (DEF_INSTALL_CMAKE_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/websocketpp)
+  set (DEF_INSTALL_CMAKE_DIR ${CMAKE_INSTALL_PREFIX}/lib/cmake/websocketpp)
 endif ()
 set (INSTALL_CMAKE_DIR ${DEF_INSTALL_CMAKE_DIR} CACHE PATH "Installation directory for CMake files")
 


### PR DESCRIPTION
The library is header-only so the CMake config should be installed into the architecture-independent directory to allow it to be found regardless of the targeted architecture and the architecture it was installed on.
